### PR TITLE
Redis 8.2.1

### DIFF
--- a/.github/workflows/publish_unstable_package.yaml
+++ b/.github/workflows/publish_unstable_package.yaml
@@ -9,7 +9,7 @@ on:
       - release/8.*
 
 env:
-  VERSION: "8.2.0"
+  VERSION: "8.2.1"
 
 jobs:
   build-containers:


### PR DESCRIPTION
This PR updates the Redis version to 8.2.1 in the `publish_unstable_package.yaml` workflow, which is used for building and publishing Redis RPM packages with modules.

Changes:
- Updated VERSION from "8.2.0" to "8.2.1" in `.github/workflows/publish_unstable_package.yaml`

This follows the same pattern as previous Redis version bumps and ensures that the CI/CD pipeline uses the correct Redis version when creating packages.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author