### PR TITLE
Update Dockerfile Base Image

### DIFF
--- a/dockerfiles/Dockerfile.rockylinux8
+++ b/dockerfiles/Dockerfile.rockylinux8
@@ -1,4 +1,4 @@
-FROM rockylinux:8
+FROM docker.io/rockylinux/rockylinux:8
 
 # Update system and install basic tools
 RUN dnf clean all && \

--- a/dockerfiles/Dockerfile.rockylinux9
+++ b/dockerfiles/Dockerfile.rockylinux9
@@ -1,4 +1,4 @@
-FROM rockylinux:9
+FROM docker.io/rockylinux/rockylinux:9
 
 # Install basic packages and development tools
 RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/goreleaser.repo; \


### PR DESCRIPTION
The [old base image](https://hub.docker.com/_/rockylinux) hasn't been updated in over a year. The [new one](https://hub.docker.com/r/rockylinux/rockylinux) is maintained by the Rocky Linux project itself and updated regularly.