### PR TITLE
Updates scripts/preremove.sh to stop remove service on RPM removal only

### DIFF
--- a/.github/workflows/publish_unstable_package.yaml
+++ b/.github/workflows/publish_unstable_package.yaml
@@ -9,7 +9,7 @@ on:
       - release/8.0
 
 env:
-  VERSION: "8.0.1"
+  VERSION: "8.0.2"
 
 jobs:
   build-containers:

--- a/.github/workflows/publish_unstable_package.yaml
+++ b/.github/workflows/publish_unstable_package.yaml
@@ -9,7 +9,7 @@ on:
       - release/8.0
 
 env:
-  VERSION: "8.0.2"
+  VERSION: "8.0.3"
 
 jobs:
   build-containers:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Redis CE with Modules - RPM Packaging
+# Redis Open Source with Modules - RPM Packaging
 
 This repository provides tools and configurations to build and package Redis Open Source with additional modules as RPM packages for RHEL-compatible distributions.
 

--- a/scripts/preremove.sh
+++ b/scripts/preremove.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
-# Stop and disable the service
-systemctl stop redis.service
-systemctl disable redis.service
+
+if [ "$1" = "0" ]; then
+    # Package removal, not an upgrade
+    systemctl stop redis.service 2>&1 || :
+    systemctl disable redis.service 2>&1 || :
+fi


### PR DESCRIPTION
Updates scripts/preremove.sh to stop remove service on RPM removal only

Fixes https://github.com/redis/redis-rpm/issues/30