### PR TITLE
rockylinux: add clang-devel and llvm to the build deps

### DIFF
--- a/dockerfiles/Dockerfile.rockylinux8
+++ b/dockerfiles/Dockerfile.rockylinux8
@@ -24,6 +24,8 @@ RUN dnf install -y --nobest --skip-broken \
     unzip \
     rsync \
     clang \
+    clang-devel \
+    llvm \
     curl \
     libtool \
     automake \

--- a/dockerfiles/Dockerfile.rockylinux9
+++ b/dockerfiles/Dockerfile.rockylinux9
@@ -22,6 +22,8 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
     unzip \
     rsync \
     clang \
+    clang-devel \
+    llvm \
     curl \
     libtool \
     automake \


### PR DESCRIPTION
Context
RediSearch adopted bindgen (via clang-sys), which requires:
- libclang.so (provided by clang-devel on RHEL/Rocky)
- llvm-config (provided by llvm)

Problem
Our builder images lacked these, causing CI failures when building modules (RediSearch) with errors like:
- "couldn't execute llvm-config"
- "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so']"

