### PR TITLE
Enable LTO for RediSearch module when Redis is builed with modules

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -92,8 +92,15 @@ runs:
         export DISABLE_WERRORS=yes
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
-        # Override RediSearch's new LTO=1 default; toolchain support TBD.
-        export LTO=0
+        # Enable RediSearch LTO only where LLVM 21 is available (Rocky 10).
+        # Rocky 8/9 lack libstdc++ with GLIBCXX_3.4.30+ that upstream LLVM 21
+        # binaries require, so keep LTO=0 there.
+        if [ -x /opt/llvm/bin/clang-21 ]; then
+          export LTO=1
+          export PATH=/opt/llvm/bin:$PATH
+        else
+          export LTO=0
+        fi
 
         if [ "${{ steps.version.outputs.VERSION }}" = "unstable" ]; then
           # Clone Redis unstable branch instead of downloading release tarball

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -94,8 +94,8 @@ runs:
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
         # Enable RediSearch LTO only where our LLVM toolchain is installed.
-        # Rocky 8 lacks a compatible libstdc++ runtime for the prebuilt LLVM
-        # binaries so it has no /opt/llvm; Rocky 9 and 10 do.
+        # Rocky 8 and 9 lacks a compatible libstdc++ runtime for the prebuilt LLVM
+        # binaries so it has no /opt/llvm; Rocky 10 does.
         if [ -x /opt/llvm/bin/clang ]; then
           export LTO=1
           export PATH=/opt/llvm/bin:$PATH

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -83,7 +83,8 @@ runs:
         # Source gcc-toolset environment (version depends on distro)
         if [ -f /etc/profile.d/gcc-toolset-15.sh ]; then
           source /etc/profile.d/gcc-toolset-15.sh
-        # Fallback for Rocky Linux 8/9
+        elif [ -f /etc/profile.d/gcc-toolset-14.sh ]; then
+          source /etc/profile.d/gcc-toolset-14.sh
         elif [ -f /etc/profile.d/gcc-toolset-13.sh ]; then
           source /etc/profile.d/gcc-toolset-13.sh
         fi
@@ -92,10 +93,10 @@ runs:
         export DISABLE_WERRORS=yes
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
-        # Enable RediSearch LTO only where LLVM 21 is available (Rocky 10).
-        # Rocky 8/9 lack libstdc++ with GLIBCXX_3.4.30+ that upstream LLVM 21
-        # binaries require, so keep LTO=0 there.
-        if [ -x /opt/llvm/bin/clang-21 ]; then
+        # Enable RediSearch LTO only where our LLVM toolchain is installed.
+        # Rocky 8 lacks a compatible libstdc++ runtime for the prebuilt LLVM
+        # binaries so it has no /opt/llvm; Rocky 9 and 10 do.
+        if [ -x /opt/llvm/bin/clang ]; then
           export LTO=1
           export PATH=/opt/llvm/bin:$PATH
         else

--- a/dockerfiles/Dockerfile.rockylinux10
+++ b/dockerfiles/Dockerfile.rockylinux10
@@ -42,8 +42,12 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
 COPY install/install_cmake.sh /tmp/
 RUN bash /tmp/install_cmake.sh
 
+# Install LLVM 21 for RediSearch LTO (Rocky 10 only; see install_llvm.sh).
+COPY install/install_llvm.sh /tmp/
+RUN bash /tmp/install_llvm.sh
+
 # Set environment
-ENV PATH="/usr/local/bin:/opt/venv/bin:${PATH}"
+ENV PATH="/opt/llvm/bin:/usr/local/bin:/opt/venv/bin:${PATH}"
 WORKDIR /build
 
 # Default command

--- a/dockerfiles/Dockerfile.rockylinux9
+++ b/dockerfiles/Dockerfile.rockylinux9
@@ -39,8 +39,22 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
 COPY install/install_cmake.sh /tmp/
 RUN bash /tmp/install_cmake.sh
 
+# Rocky 9's system libstdc++ (GCC 11, GLIBCXX_3.4.28) is too old for the
+# prebuilt LLVM 21 binaries (need 3.4.30+). Pull a newer libstdc++ from
+# Fedora 43 which provides GLIBCXX_3.4.34 and is built against a compatible
+RUN dnf install -y \
+    --repofrompath=fedora,'https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Everything/$basearch/os/' \
+    --setopt=fedora.gpgcheck=0 \
+    --disablerepo='*' --enablerepo=fedora \
+    libstdc++ && \
+    dnf clean all
+
+# Install LLVM 21 for RediSearch LTO (Rocky 9 + Rocky 10; see install_llvm.sh).
+COPY install/install_llvm.sh /tmp/
+RUN bash /tmp/install_llvm.sh
+
 # Set environment
-ENV PATH="/usr/local/bin:/opt/venv/bin:${PATH}"
+ENV PATH="/opt/llvm/bin:/usr/local/bin:/opt/venv/bin:${PATH}"
 WORKDIR /build
 
 # Default command

--- a/dockerfiles/Dockerfile.rockylinux9
+++ b/dockerfiles/Dockerfile.rockylinux9
@@ -39,22 +39,8 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
 COPY install/install_cmake.sh /tmp/
 RUN bash /tmp/install_cmake.sh
 
-# Rocky 9's system libstdc++ (GCC 11, GLIBCXX_3.4.28) is too old for the
-# prebuilt LLVM 21 binaries (need 3.4.30+). Pull a newer libstdc++ from
-# Fedora 43 which provides GLIBCXX_3.4.34 and is built against a compatible
-RUN dnf install -y \
-    --repofrompath=fedora,'https://dl.fedoraproject.org/pub/fedora/linux/releases/43/Everything/$basearch/os/' \
-    --setopt=fedora.gpgcheck=0 \
-    --disablerepo='*' --enablerepo=fedora \
-    libstdc++ && \
-    dnf clean all
-
-# Install LLVM 21 for RediSearch LTO (Rocky 9 + Rocky 10; see install_llvm.sh).
-COPY install/install_llvm.sh /tmp/
-RUN bash /tmp/install_llvm.sh
-
 # Set environment
-ENV PATH="/opt/llvm/bin:/usr/local/bin:/opt/venv/bin:${PATH}"
+ENV PATH="/usr/local/bin:/opt/venv/bin:${PATH}"
 WORKDIR /build
 
 # Default command

--- a/install/install_llvm.sh
+++ b/install/install_llvm.sh
@@ -2,9 +2,9 @@
 # Install LLVM 21 for RediSearch's cross-language (C/Rust) LTO build.
 # LLVM has no dnf repo, so we use the official upstream tarball.
 #
-# Rocky 10 only: prebuilt LLVM 21 binaries need GLIBCXX_3.4.30+; Rocky 10
-# ships it (3.4.32). Rocky 8/9 don't — gcc-toolset ships compile-time headers
-# only, no newer libstdc++.so.6 runtime, so there is nothing to vendor.
+# Rocky 10 only: ships libstdc++ with GLIBCXX_3.4.32 which satisfies the
+# GLIBCXX_3.4.30+ requirement of the prebuilt LLVM 21 binaries.
+# Rocky 8 and Rocky 9 are not supported (incompatible libstdc++ at runtime).
 
 set -euo pipefail
 

--- a/install/install_llvm.sh
+++ b/install/install_llvm.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Install LLVM 21 for RediSearch's cross-language (C/Rust) LTO build.
+# LLVM has no dnf repo, so we use the official upstream tarball.
+#
+# Rocky 10 only: prebuilt LLVM 21 binaries need GLIBCXX_3.4.30+; Rocky 10
+# ships it (3.4.32). Rocky 8/9 don't — gcc-toolset ships compile-time headers
+# only, no newer libstdc++.so.6 runtime, so there is nothing to vendor.
+
+set -euo pipefail
+
+LLVM_VERSION="${LLVM_VERSION:-21.1.8}"
+MAJOR="${LLVM_VERSION%%.*}"
+
+case "$(uname -m)" in
+	x86_64)  asset="LLVM-${LLVM_VERSION}-Linux-X64.tar.xz" ;;
+	aarch64) asset="LLVM-${LLVM_VERSION}-Linux-ARM64.tar.xz" ;;
+	*) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+esac
+
+install_root="/opt/llvm-${LLVM_VERSION}"
+mkdir -p "$install_root"
+curl -fsSL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/${asset}" \
+	| tar -xJ -C "$install_root" --strip-components=1
+ln -sfn "$install_root" /opt/llvm
+
+# RediSearch's build scripts look up clang-${MAJOR}, lld-${MAJOR}, etc. on PATH;
+# the upstream tarball ships unsuffixed names only, so alias them.
+for tool in clang clang++ clang-cpp lld ld.lld ld64.lld lld-link llc opt \
+            llvm-ar llvm-nm llvm-ranlib llvm-strip llvm-objcopy llvm-objdump \
+            llvm-readelf llvm-config; do
+	src="/opt/llvm/bin/${tool}"
+	dst="/opt/llvm/bin/${tool}-${MAJOR}"
+	[ -e "$src" ] && [ ! -e "$dst" ] && ln -sfn "$src" "$dst"
+done
+
+echo 'export PATH=/opt/llvm/bin:$PATH' > /etc/profile.d/llvm.sh
+
+/opt/llvm/bin/clang-${MAJOR} --version
+/opt/llvm/bin/ld.lld-${MAJOR} --version


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the RPM build toolchain and LTO behavior, which can affect build reliability and binary compatibility across distros/architectures.
> 
> **Overview**
> **Enables RediSearch LTO for module builds where supported.** The build action now selects `gcc-toolset-14` as a fallback and conditionally sets `LTO=1` only when `/opt/llvm` is present (otherwise forces `LTO=0`).
> 
> **Updates the Rocky 10 builder image to provide the required LLVM toolchain.** `Dockerfile.rockylinux10` installs a new `install_llvm.sh` script that downloads upstream LLVM 21 into `/opt/llvm`, adds version-suffixed tool aliases expected by RediSearch, and prepends `/opt/llvm/bin` to `PATH`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8920c1958a292134214c1912534dbcb20cdecef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->