### PR TITLE
Disable LTO by seting LTO=0 for the modules build

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -92,6 +92,8 @@ runs:
         export DISABLE_WERRORS=yes
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
+        # Override RediSearch's new LTO=1 default; toolchain support TBD.
+        export LTO=0
 
         if [ "${{ steps.version.outputs.VERSION }}" = "unstable" ]; then
           # Clone Redis unstable branch instead of downloading release tarball


### PR DESCRIPTION
RediSearch's upstream Makefile now defaults LTO=1 (redis/redis@2408a15) when Redis is built with modules. Enabling LTO requires an LLVM toolchain matching rustc's bundled LLVM (Rust 1.94 ships LLVM 21) and a libstdc++ providing GLIBCXX_3.4.30+. RHEL/Rocky 9's stock libstdc++ tops out at GLIBCXX_3.4.28 (gcc 11) and the gcc-toolset packages link new C++ ABI symbols statically rather than shipping a separate runtime shared library, so getting LTO to work here would require vendoring libstdc++ from a newer EL release.

Park that work for a follow-up. Force LTO=0 in the build action so the upstream default doesn't break our nightly unstable builds in the meantime.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that forces `LTO=0` during the modules build to avoid toolchain incompatibilities with upstream defaults; primary risk is reduced build-time optimization/perf.
> 
> **Overview**
> Forces `LTO=0` in the `build-package` GitHub composite action when building Redis **with modules**, overriding RediSearch’s new default `LTO=1` so nightly/unstable RPM builds don’t break on unsupported toolchains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa801db35945d4accb7187e94d34627b6284b4f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->