### PR TITLE
Configure jemalloc for 64K pages on arm64

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -125,6 +125,15 @@ runs:
         fi
 
         # Build Redis
+        # On arm64, configure jemalloc with a 64 KiB max page size so the
+        # resulting binary runs on aarch64 hosts that use 64K pages (e.g.
+        # Rocky Linux 8 aarch64). Build runners are 4K-page, so without this
+        # jemalloc aborts with "Unsupported system page size" at startup.
+        # See https://github.com/redis/redis/issues/15185 and the side note
+        # in https://github.com/redis/redis/pull/11407.
+        if [ "${{ inputs.platform }}" = "arm64" ]; then
+          export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16"
+        fi
         make -j "$(nproc)" all
         make install PREFIX=/usr/local
         echo "Contents of /usr/local/lib/redis/modules/:"


### PR DESCRIPTION
## Summary
- On arm64, export `JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16"` before `make all` so the bundled jemalloc supports up to 64 KiB pages.
- amd64 builds are untouched.

## Why
The arm64 build runners (`ubuntu24-arm64-2-8`) use 4K pages, so jemalloc gets configured with a 4 KiB max page size. The resulting RPM then aborts at startup on aarch64 hosts that use 64K pages (default on Rocky Linux 8 aarch64, common on other distros too) with:

```
<jemalloc>: Unsupported system page size
```

This is exactly what was reported in [redis/redis#15185](https://github.com/redis/redis/issues/15185). The recommended packaging-side fix (see the side note in [redis/redis#11407](https://github.com/redis/redis/pull/11407)) is to pass `--with-lg-page=16` (= 2^16 = 64 KiB) to jemalloc's `configure`. Per the discussion in [jemalloc/jemalloc#467](https://github.com/jemalloc/jemalloc/issues/467) and [redis/redis#11170](https://github.com/redis/redis/pull/11170#issuecomment-1236265230), this is safe on recent jemalloc versions without serious VM-fragmentation side effects.

## Test plan
- [x] CI builds succeed on all arm64 matrix entries (rockylinux 8/9/10)
- [x] Resulting arm64 RPM installs and `redis-server` starts on a 64K-page aarch64 host (e.g. Rocky Linux 8 aarch64)
- [x] Resulting arm64 RPM still starts on a 4K-page aarch64 host
- [x] amd64 build and smoke tests remain green

See the [verification comment](https://github.com/redis/redis-rpm/pull/59#issuecomment-4507754133) below for evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the arm64 build environment for Redis by altering jemalloc configuration, which could affect runtime behavior/memory characteristics and the resulting packaged binaries. Scope is limited to the GitHub Actions packaging workflow and is gated to `arm64` builds.
>
> **Overview**
> Adjusts the RPM build action to set `JEMALLOC_CONFIGURE_OPTS=--with-lg-page=16` when `inputs.platform` is `arm64`, ensuring the bundled jemalloc supports 64KiB page-size aarch64 hosts.
>
> amd64 builds and the rest of the packaging flow are unchanged; this only modifies how Redis is compiled in the `Build Redis with modules` step.
>
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 314625ce34e3f1afedffc18fcf96afa3a79337f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->