### PR TITLE
RED-198334 Bump GH Actions off Node 20 (release/8.8)

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -175,7 +175,7 @@ runs:
 
     - name: Upload logs when failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: build-failure-${{ inputs.platform }}-${{ inputs.distro }}${{ inputs.distro_version }}
         path: logs/${{ env.LOG_FILENAME }}
@@ -189,7 +189,7 @@ runs:
         docker rm builder || true
 
     - name: Upload RPM artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: rpm-${{ inputs.distro }}${{ inputs.distro_version }}-${{ inputs.platform }}
         path: dist/*.rpm

--- a/.github/actions/run-smoke-tests/action.yml
+++ b/.github/actions/run-smoke-tests/action.yml
@@ -22,7 +22,7 @@ runs:
   using: "composite"
   steps:
     - name: Download RPM artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: ${{ inputs.test_artifact_name }}
         run-id: ${{ inputs.run_id }}

--- a/.github/actions/update-redis-version/action.yml
+++ b/.github/actions/update-redis-version/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Create verified commit
       if: steps.update-version.outputs.changed_files != ''
-      uses: iarekylew00t/verified-bot-commit@v1
+      uses: iarekylew00t/verified-bot-commit@v2
       with:
         message: "Update Redis version to ${{ inputs.release_tag }}"
         files: ${{ steps.update-version.outputs.changed_files }}

--- a/.github/actions/upload-packages/action.yml
+++ b/.github/actions/upload-packages/action.yml
@@ -54,13 +54,13 @@ runs:
         fi
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@v6
       with:
         role-to-assume: ${{ inputs.RPM_S3_IAM_ARN }}
         aws-region: ${{ inputs.RPM_S3_REGION }}
 
     - name: Download all RPM artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         pattern: rpm-*
         path: all-rpms

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -42,7 +42,7 @@ jobs:
         include: ${{ fromJSON(inputs.BUILD_OS) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
@@ -75,7 +75,7 @@ jobs:
         include: ${{ fromJSON(inputs.TEST_OS) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || (inputs.release_tag != '' && needs.build-package.outputs.release_version_branch || '') }}
 

--- a/.github/workflows/build_workflow_containers.yaml
+++ b/.github/workflows/build_workflow_containers.yaml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref }}
 
@@ -44,18 +44,18 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.populate-env-vars.outputs.BUILD_CONTAINER_OS) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Generate tags
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -72,7 +72,7 @@ jobs:
             type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }}
 
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: dockerfiles/Dockerfile.${{ matrix.distro }}${{ matrix.distro_version }}
@@ -108,7 +108,7 @@ jobs:
         include: ${{ fromJSON(needs.get-unique-distros.outputs.unique_distros) }}
     steps:
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate Redis Release Archive
         uses: redis-developer/redis-oss-release-automation/.github/actions/validate-redis-release-archive@main
@@ -79,7 +79,7 @@ jobs:
           RELEASE_HANDLE
 
       - name: Upload release handle artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_handle
           path: result.json
@@ -93,7 +93,7 @@ jobs:
     if: failure()
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Detect env name
         id: detect-env

--- a/.github/workflows/release_publish.yml
+++ b/.github/workflows/release_publish.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate inputs
         id: validate-inputs
@@ -134,7 +134,7 @@ jobs:
           RESULT
 
       - name: Upload publish result artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release_info
           path: result.json

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: >-
             ${{ (github.ref_name == 'unstable'


### PR DESCRIPTION
## Summary
Cherry-pick of [#60](https://github.com/redis/redis-rpm/pull/60) onto `release/8.8`. Bump GitHub Actions still running on Node 20 ahead of the June 16, 2026 deprecation deadline.

- Bump `actions/checkout@v4` -> `@v6` (7 sites), `actions/upload-artifact@v4` -> `@v7` (4 sites), `actions/download-artifact@v4` -> `@v7` (2 sites)
- Bump `docker/*` actions in `build_workflow_containers.yaml`: `login` v3->v4, `setup-buildx` v3->v4, `setup-qemu` v3->v4, `metadata` v5->v6, `build-push` v5->v7
- Bump `aws-actions/configure-aws-credentials@v4` -> `@v6` and `iarekylew00t/verified-bot-commit@v1` -> `@v2`
- Clean cherry-pick, no conflicts

## Test plan
- [ ] `build-n-test-all-distros.yml` PR run builds + smoke-tests RPM packages cleanly
- [ ] `release_build_and_test.yml` workflow_dispatch run produces verified bot commit + uploads release artifacts
- [ ] `release_publish.yml` uploads RPM packages to S3 cleanly with `configure-aws-credentials@v6`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only CI changes with no Redis packaging or application logic; main risk is workflow compatibility with newer action majors, which the test plan covers.
> 
> **Overview**
> Bumps GitHub Actions and related third-party actions across **composite actions** and **workflows** so CI stays on supported runtimes ahead of the Node 20 deprecation (June 2026). This is a cherry-pick onto `release/8.8`; behavior of build, test, and publish steps is unchanged aside from action versions.
> 
> **Core GitHub actions:** `actions/checkout` **v4 → v6** in build/test/release workflows; `actions/upload-artifact` **v4 → v7** (RPM artifacts, failure logs, release handles); `actions/download-artifact` **v4 → v7** in smoke tests and S3 upload.
> 
> **Release path:** `aws-actions/configure-aws-credentials` **v4 → v6** for RPM S3 uploads; `iarekylew00t/verified-bot-commit` **v1 → v2** when updating `.redis_version`.
> 
> **Builder images:** In `build_workflow_containers.yaml`, Docker actions are bumped (`setup-qemu`, `setup-buildx`, `login` to v4; `metadata` to v6; `build-push` to v7).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dde8b33c109ed6692a66d404732c5a9307f03199. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->