### PR TITLE
Fix builder image tag clobbering and cache thrash

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -35,7 +35,7 @@ runs:
         docker run -d --name builder \
           -v "$PWD:/workspace" \
           -w /workspace \
-          ghcr.io/${{ github.repository }}/builder:${{ inputs.distro }}${{ inputs.distro_version }} \
+          ghcr.io/${{ github.repository }}/builder:${{ inputs.distro }}${{ inputs.distro_version }}-${{ github.sha }} \
           bash -c 'touch ./.started && sleep infinity'
           echo "Waiting for container to start..."
           timeout -v 5 bash -c 'while [ ! -f ./.started ]; do sleep 0.1; done'

--- a/.github/workflows/build_workflow_containers.yaml
+++ b/.github/workflows/build_workflow_containers.yaml
@@ -61,15 +61,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve cache branch name
+        id: cache_branch
+        shell: bash
+        env:
+          # On PRs use the base branch (e.g. unstable); otherwise the branch itself.
+          REF: ${{ github.base_ref || github.ref_name }}
+        run: echo "name=${REF//\//-}" >> "$GITHUB_OUTPUT"
+
       - name: Generate tags
         id: meta
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ github.sha }}
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }}
+            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ github.sha }}-${{ matrix.platform }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -80,8 +86,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache.${{ matrix.distro }}${{ matrix.distro_version }}.${{ matrix.platform }}
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache.${{ matrix.distro }}${{ matrix.distro_version }}.${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache.${{ matrix.distro }}${{ matrix.distro_version }}.${{ matrix.platform }}.${{ steps.cache_branch.outputs.name }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache.{2}{3}.{4}.{5},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.distro, matrix.distro_version, matrix.platform, steps.cache_branch.outputs.name) || '' }}
 
   get-unique-distros:
     needs: populate-env-vars
@@ -116,10 +122,10 @@ jobs:
 
       - name: Merge manifests
         run: |
-          # Get unique distro+version combinations
           distro_version="${{ matrix.distro }}${{ matrix.distro_version }}"
+          sha="${{ github.sha }}"
 
-          # Create multi-arch manifest
-          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-arm64
+          # Create SHA-pinned multi-arch manifest from the per-arch SHA tags
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha}-arm64


### PR DESCRIPTION
The bare builder tag (e.g. :rockylinux9) was pushed single-arch by every per-arch build job and only made multi-arch by merge-manifests, so a concurrent run could overwrite it with a single-arch image and break the consumer ("no matching manifest for linux/arm64"). The registry build cache was also keyed without the branch, so different branches evicted each other's layers.

- Push only SHA-pinned per-arch tags ({distro}{ver}-{sha}-{platform})
- Build the SHA-pinned multi-arch manifest in merge-manifests
- Consume :{distro}{ver}-{sha} in build-package (immune to other runs)
- Namespace the build cache per branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only tagging and cache key changes; no runtime application code, with the main operational note that consumers must use the new SHA-pinned builder tag pattern.
> 
> **Overview**
> **Fixes concurrent CI runs clobbering builder images and thrashing Docker build cache.**
> 
> Builder images are no longer published or consumed via the bare `:{distro}{ver}` tag. Per-arch builds push only `:{distro}{ver}-{sha}-{platform}`, **merge-manifests** assembles the multi-arch manifest at `:{distro}{ver}-{sha}`, and **build-package** pulls that SHA-pinned tag so another workflow cannot replace the image with a single-arch layer.
> 
> Registry **buildcache** refs now include a branch-derived suffix (PRs use the base branch), and **cache-to** is skipped on pull requests so PR jobs can reuse cache without overwriting branch caches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41f176ff5cddf5807c6704a3f9458e0728d88a90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->