### PR TITLE
[8.0] Pin builder image to commit SHA to prevent cross-run tag clobbering

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -35,7 +35,7 @@ runs:
         docker run -d --name builder \
           -v "$PWD:/workspace" \
           -w /workspace \
-          ghcr.io/${{ github.repository }}/builder:${{ inputs.distro }}${{ inputs.distro_version }} \
+          ghcr.io/${{ github.repository }}/builder:${{ inputs.distro }}${{ inputs.distro_version }}-${{ github.sha }} \
           bash -c 'touch ./.started && sleep infinity'
           echo "Waiting for container to start..."
           timeout -v 5 bash -c 'while [ ! -f ./.started ]; do sleep 0.1; done'

--- a/.github/workflows/build_workflow_containers.yaml
+++ b/.github/workflows/build_workflow_containers.yaml
@@ -67,9 +67,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ github.sha }}
-            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }}
+            type=raw,value=${{ matrix.distro }}${{ matrix.distro_version }}-${{ github.sha }}-${{ matrix.platform }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -116,10 +114,10 @@ jobs:
 
       - name: Merge manifests
         run: |
-          # Get unique distro+version combinations
           distro_version="${{ matrix.distro }}${{ matrix.distro_version }}"
+          sha="${{ github.sha }}"
 
-          # Create multi-arch manifest
-          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version} \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-amd64 \
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-arm64
+          # Create SHA-pinned multi-arch manifest from the per-arch SHA tags
+          docker buildx imagetools create -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha} \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha}-amd64 \
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${distro_version}-${sha}-arm64


### PR DESCRIPTION
Backport of #67 to `release/8.0`.

The bare builder tag (e.g. `:rockylinux9`) was pushed single-arch by every per-arch build job and only made multi-arch by `merge-manifests`, so a concurrent run could overwrite it with a single-arch image and break the consumer (`no matching manifest for linux/arm64`).

- Push only SHA-pinned per-arch tags (`{distro}{ver}-{sha}-{platform}`)
- Build the SHA-pinned multi-arch manifest in `merge-manifests`
- Consume `:{distro}{ver}-{sha}` in `build-package` (immune to other runs)

Cherry-picked from commit 0086852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions container tagging and the build-package image reference; release builds must still run container build and package build on the same SHA.
> 
> **Overview**
> **CI builder images are no longer published or consumed via floating distro-only tags** (e.g. `:rockylinux9`). Per-arch builds now push only **`{distro}{ver}-{sha}-{platform}`**, and **`merge-manifests`** assembles the multi-arch manifest **`{distro}{ver}-{sha}`** from those SHA-pinned arch tags.
> 
> **`build-package`** pulls the builder with **`{distro}{ver}-${{ github.sha }}`**, so package builds use the image built in the same commit and are not affected when another workflow run overwrites a shared tag (e.g. single-arch manifest / missing `linux/arm64`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87e6982cd3dce2aa44328463da54f06c3ba9f494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->