### PR TITLE
Adopt new redis modules build system

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -88,9 +88,6 @@ runs:
         elif [ -f /etc/profile.d/gcc-toolset-13.sh ]; then
           source /etc/profile.d/gcc-toolset-13.sh
         fi
-        export BUILD_WITH_MODULES=yes
-        export INSTALL_RUST_TOOLCHAIN=yes
-        export DISABLE_WERRORS=yes
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
         # Enable RediSearch LTO only where our LLVM toolchain is installed.
@@ -108,15 +105,14 @@ runs:
           git clone --depth 1 https://github.com/redis/redis.git -b unstable
           cd redis
 
-          # Update module versions to use master branch
-          echo "Updating module versions to use master branch..."
-          for module in redisbloom redisearch redistimeseries redisjson; do
-            if [ -f "modules/${module}/Makefile" ]; then
-              echo "Updating ${module} to use master branch"
-              sed -i "s/MODULE_VERSION = .*/MODULE_VERSION = master/" "modules/${module}/Makefile"
-              cat "modules/${module}/Makefile" | grep "MODULE_VERSION"
-            fi
-          done
+          # Point every module at the master branch in the manifest.
+          echo "Updating module refs to use master branch..."
+          if [ ! -f modules/modules.yaml ]; then
+            echo "modules/modules.yaml not found"
+            exit 1
+          fi
+          yq -i '.modules[].ref = "master"' modules/modules.yaml
+          yq '.modules[] | .name + "=" + .ref' modules/modules.yaml
         else
           # Download and extract Redis source
           curl -L "https://github.com/redis/redis/archive/refs/tags/${{ steps.version.outputs.VERSION }}.tar.gz" -o redis.tar.gz
@@ -134,8 +130,9 @@ runs:
         if [ "${{ inputs.platform }}" = "arm64" ]; then
           export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16"
         fi
-        make -j "$(nproc)" all
-        make install PREFIX=/usr/local
+        make modules-update MODULES_UPDATE_SHALLOW=1
+        make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
+        make -j "$(nproc)" deploy PREFIX=/usr/local
         echo "Contents of /usr/local/lib/redis/modules/:"
         ls -la /usr/local/lib/redis/modules/
 

--- a/dockerfiles/Dockerfile.rockylinux10
+++ b/dockerfiles/Dockerfile.rockylinux10
@@ -1,5 +1,8 @@
 FROM rockylinux/rockylinux:10
 
+ARG TARGETARCH
+ARG YQ_VERSION=v4.44.3
+
 # Install basic packages and development tools
 RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/goreleaser.repo; \
     dnf clean all && \
@@ -28,6 +31,12 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
     autoconf \
     jq \
     systemd-devel; \
+    \
+    # yq-go for structured modules.yaml edits
+    YQ_ARCH="${TARGETARCH:-$(uname -m)}"; \
+    case "$YQ_ARCH" in x86_64) YQ_ARCH=amd64 ;; aarch64) YQ_ARCH=arm64 ;; esac; \
+    curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}"; \
+    chmod +x /usr/local/bin/yq; \
     \
     # Python venv
     python3 -m venv /opt/venv; \

--- a/dockerfiles/Dockerfile.rockylinux8
+++ b/dockerfiles/Dockerfile.rockylinux8
@@ -1,5 +1,8 @@
 FROM rockylinux:8
 
+ARG TARGETARCH
+ARG YQ_VERSION=v4.44.3
+
 # Update system and install basic tools
 RUN dnf clean all && \
     echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/goreleaser.repo; \
@@ -30,6 +33,12 @@ RUN dnf install -y --nobest --skip-broken \
     autoconf \
     jq \
     systemd-devel; \
+    \
+    # yq-go for structured modules.yaml edits
+    YQ_ARCH="${TARGETARCH:-$(uname -m)}"; \
+    case "$YQ_ARCH" in x86_64) YQ_ARCH=amd64 ;; aarch64) YQ_ARCH=arm64 ;; esac; \
+    curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}"; \
+    chmod +x /usr/local/bin/yq; \
     \
     # Python venv
     python3.11 -m venv /opt/venv; \

--- a/dockerfiles/Dockerfile.rockylinux9
+++ b/dockerfiles/Dockerfile.rockylinux9
@@ -1,5 +1,8 @@
 FROM rockylinux:9
 
+ARG TARGETARCH
+ARG YQ_VERSION=v4.44.3
+
 # Install basic packages and development tools
 RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum/\nenabled=1\ngpgcheck=0' > /etc/yum.repos.d/goreleaser.repo; \
     dnf clean all && \
@@ -28,6 +31,12 @@ RUN echo '[goreleaser]\nname=GoReleaser\nbaseurl=https://repo.goreleaser.com/yum
     autoconf \
     jq \
     systemd-devel; \
+    \
+    # yq-go for structured modules.yaml edits
+    YQ_ARCH="${TARGETARCH:-$(uname -m)}"; \
+    case "$YQ_ARCH" in x86_64) YQ_ARCH=amd64 ;; aarch64) YQ_ARCH=arm64 ;; esac; \
+    curl -fsSL -o /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${YQ_ARCH}"; \
+    chmod +x /usr/local/bin/yq; \
     \
     # Python venv
     python3 -m venv /opt/venv; \


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the full Redis+modules compile path for all Rocky RPM builds; failures would surface as broken CI artifacts rather than production runtime, but the new upstream make targets must match every release and unstable branch.
> 
> **Overview**
> RPM packaging now follows Redis’s **modules manifest workflow** instead of per-module `Makefile` `sed` hacks and legacy `BUILD_WITH_MODULES` / `make all` + `make install`.
> 
> For **unstable** builds, module pins are set by editing `modules/modules.yaml` with **yq** (all `ref` values → `master`), with a hard fail if the manifest is missing. **Rocky Linux 8/9/10** builder images install **yq** (arch-aware download) to support that step.
> 
> The compile sequence is now **`make modules-update`**, **`make -C modules install-rust`**, then **`make deploy`** to `/usr/local`, with shallow module fetch and explicit Rust toolchain install on the modules target. Several old build env exports (`BUILD_WITH_MODULES`, top-level `INSTALL_RUST_TOOLCHAIN`, `DISABLE_WERRORS`) are dropped in favor of this flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b7f557d1b0ff202f1e1358d5f58f0b6b3628fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->