### PR TITLE
Handle modern modulest build system conditionally

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -14,6 +14,9 @@ inputs:
   release_tag:
     description: "Release tag (version or 'unstable')"
     required: true
+  modern_modules_build:
+    description: "Whether to use modern Redis modules build flow"
+    required: true
 
 runs:
   using: "composite"
@@ -90,6 +93,11 @@ runs:
         fi
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
+        if [ "${{ inputs.modern_modules_build }}" != "true" ]; then
+          export BUILD_WITH_MODULES=yes
+          export INSTALL_RUST_TOOLCHAIN=yes
+          export DISABLE_WERRORS=yes
+        fi
         # Enable RediSearch LTO only where our LLVM toolchain is installed.
         # Rocky 8 and 9 lacks a compatible libstdc++ runtime for the prebuilt LLVM
         # binaries so it has no /opt/llvm; Rocky 10 does.
@@ -130,9 +138,14 @@ runs:
         if [ "${{ inputs.platform }}" = "arm64" ]; then
           export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16"
         fi
-        make modules-update MODULES_UPDATE_SHALLOW=1
-        make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
-        make -j "$(nproc)" deploy PREFIX=/usr/local
+        if [ "${{ inputs.modern_modules_build }}" = "true" ]; then
+          make modules-update MODULES_UPDATE_SHALLOW=1
+          make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
+          make -j "$(nproc)" deploy PREFIX=/usr/local
+        else
+          make -j "$(nproc)" all
+          make install PREFIX=/usr/local
+        fi
         echo "Contents of /usr/local/lib/redis/modules/:"
         ls -la /usr/local/lib/redis/modules/
 

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -14,9 +14,6 @@ inputs:
   release_tag:
     description: "Release tag (version or 'unstable')"
     required: true
-  modern_modules_build:
-    description: "Whether to use modern Redis modules build flow"
-    required: true
 
 runs:
   using: "composite"
@@ -93,11 +90,6 @@ runs:
         fi
         export BUILD_TLS=yes
         export USE_SYSTEMD=yes
-        if [ "${{ inputs.modern_modules_build }}" != "true" ]; then
-          export BUILD_WITH_MODULES=yes
-          export INSTALL_RUST_TOOLCHAIN=yes
-          export DISABLE_WERRORS=yes
-        fi
         # Enable RediSearch LTO only where our LLVM toolchain is installed.
         # Rocky 8 and 9 lacks a compatible libstdc++ runtime for the prebuilt LLVM
         # binaries so it has no /opt/llvm; Rocky 10 does.
@@ -128,6 +120,19 @@ runs:
           cd redis-${{ steps.version.outputs.VERSION }}
         fi
 
+        if [ "${{ steps.version.outputs.VERSION }}" = "unstable" ] || [ -f modules/modules.yaml ]; then
+          MODERN_MODULES_BUILD=true
+        else
+          MODERN_MODULES_BUILD=false
+        fi
+        echo "Modern modules build: $MODERN_MODULES_BUILD"
+
+        if [ "$MODERN_MODULES_BUILD" != "true" ]; then
+          export BUILD_WITH_MODULES=yes
+          export INSTALL_RUST_TOOLCHAIN=yes
+          export DISABLE_WERRORS=yes
+        fi
+
         # Build Redis
         # On arm64, configure jemalloc with a 64 KiB max page size so the
         # resulting binary runs on aarch64 hosts that use 64K pages (e.g.
@@ -138,7 +143,7 @@ runs:
         if [ "${{ inputs.platform }}" = "arm64" ]; then
           export JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16"
         fi
-        if [ "${{ inputs.modern_modules_build }}" = "true" ]; then
+        if [ "$MODERN_MODULES_BUILD" = "true" ]; then
           make modules-update MODULES_UPDATE_SHALLOW=1
           make -C modules install-rust INSTALL_RUST_TOOLCHAIN=yes
           make -j "$(nproc)" deploy PREFIX=/usr/local

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -22,13 +22,17 @@ on:
       TEST_OS:
         type: string
         description: "JSON array of test configurations"
+      MODERN_MODULES_BUILD:
+        type: string
+        description: "Whether to use modern Redis modules build flow"
+        default: "false"
 
 jobs:
   build-containers:
     name: Build Builder Containers
     uses: ./.github/workflows/build_workflow_containers.yaml
     with:
-      checkout_ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+      checkout_ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
   build-package:
     name: Build RPM (${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }})
@@ -44,7 +48,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || '' }}
+          ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || '' }}
 
       - name: Ensure Release Branch
         if: inputs.release_tag != '' && inputs.release_tag != 'unstable'
@@ -62,6 +66,7 @@ jobs:
           distro_version: ${{ matrix.distro_version }}
           platform: ${{ matrix.platform }}
           release_tag: ${{ inputs.release_tag }}
+          modern_modules_build: ${{ inputs.MODERN_MODULES_BUILD }}
 
   run-smoke-tests:
     name: Test RPM (${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }})
@@ -77,7 +82,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release_tag == 'unstable' && 'unstable' || (inputs.release_tag != '' && needs.build-package.outputs.release_version_branch || '') }}
+          ref: ${{ github.event_name != 'pull_request' && inputs.release_tag == 'unstable' && 'unstable' || (inputs.release_tag != '' && inputs.release_tag != 'unstable' && needs.build-package.outputs.release_version_branch || '') }}
 
       - name: Run smoke tests
         uses: ./.github/actions/run-smoke-tests

--- a/.github/workflows/build-n-test-all-distros.yml
+++ b/.github/workflows/build-n-test-all-distros.yml
@@ -22,10 +22,6 @@ on:
       TEST_OS:
         type: string
         description: "JSON array of test configurations"
-      MODERN_MODULES_BUILD:
-        type: string
-        description: "Whether to use modern Redis modules build flow"
-        default: "false"
 
 jobs:
   build-containers:
@@ -66,7 +62,6 @@ jobs:
           distro_version: ${{ matrix.distro_version }}
           platform: ${{ matrix.platform }}
           release_tag: ${{ inputs.release_tag }}
-          modern_modules_build: ${{ inputs.MODERN_MODULES_BUILD }}
 
   run-smoke-tests:
     name: Test RPM (${{ matrix.distro }}${{ matrix.distro_version }}-${{ matrix.platform }})

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -23,6 +23,7 @@ jobs:
     outputs:
       BUILD_OS: ${{ steps.populate-env-vars.outputs.BUILD_OS }}
       TEST_OS: ${{ steps.populate-env-vars.outputs.TEST_OS }}
+      MODERN_MODULES_BUILD: ${{ steps.module-build-system.outputs.MODERN_MODULES_BUILD }}
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
@@ -53,6 +54,12 @@ jobs:
         id: populate-env-vars
         uses: ./.github/actions/parse-env-file
 
+      - name: Determine module build system
+        id: module-build-system
+        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@master
+        with:
+          release_tag: ${{ github.event.inputs.release_tag }}
+
   build-n-test:
     needs:
       - prepare-release
@@ -60,6 +67,7 @@ jobs:
     with:
       BUILD_OS: ${{ needs.prepare-release.outputs.BUILD_OS }}
       TEST_OS: ${{ needs.prepare-release.outputs.TEST_OS }}
+      MODERN_MODULES_BUILD: ${{ needs.prepare-release.outputs.MODERN_MODULES_BUILD }}
       release_tag: ${{ inputs.release_tag }}
 
   create-release-handle:

--- a/.github/workflows/release_build_and_test.yml
+++ b/.github/workflows/release_build_and_test.yml
@@ -23,7 +23,6 @@ jobs:
     outputs:
       BUILD_OS: ${{ steps.populate-env-vars.outputs.BUILD_OS }}
       TEST_OS: ${{ steps.populate-env-vars.outputs.TEST_OS }}
-      MODERN_MODULES_BUILD: ${{ steps.module-build-system.outputs.MODERN_MODULES_BUILD }}
     runs-on: ["ubuntu-latest"]
     steps:
       - name: Checkout code
@@ -54,11 +53,6 @@ jobs:
         id: populate-env-vars
         uses: ./.github/actions/parse-env-file
 
-      - name: Determine module build system
-        id: module-build-system
-        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@master
-        with:
-          release_tag: ${{ github.event.inputs.release_tag }}
 
   build-n-test:
     needs:
@@ -67,7 +61,6 @@ jobs:
     with:
       BUILD_OS: ${{ needs.prepare-release.outputs.BUILD_OS }}
       TEST_OS: ${{ needs.prepare-release.outputs.TEST_OS }}
-      MODERN_MODULES_BUILD: ${{ needs.prepare-release.outputs.MODERN_MODULES_BUILD }}
       release_tag: ${{ inputs.release_tag }}
 
   create-release-handle:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -23,6 +23,7 @@ on:
 
 run-name: >-
         ${{ (github.ref_name == 'unstable'
+        || github.base_ref == 'unstable'
         || github.event_name == 'workflow_dispatch'
         || github.event_name == 'workflow_call'
         || github.event_name == 'schedule')
@@ -38,10 +39,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: >-
-            ${{ (github.ref_name == 'unstable'
+            ${{ (github.event_name != 'pull_request'
+            && (github.ref_name == 'unstable'
             || github.event_name == 'workflow_dispatch'
             || github.event_name == 'workflow_call'
-            || github.event_name == 'schedule')
+            || github.event_name == 'schedule'))
             && 'unstable'
             || ''
             }}
@@ -49,9 +51,37 @@ jobs:
       - name: Parse vars
         id: parse
         uses: ./.github/actions/parse-env-file
+
+      - name: Determine Redis version for module build system
+        id: module-version
+        shell: bash
+        env:
+          IS_UNSTABLE_BUILD: >-
+            ${{ github.ref_name == 'unstable'
+            || github.base_ref == 'unstable'
+            || github.event_name == 'workflow_dispatch'
+            || github.event_name == 'workflow_call'
+            || github.event_name == 'schedule'
+            }}
+        run: |
+          set -euo pipefail
+          if [ "$IS_UNSTABLE_BUILD" = "true" ]; then
+            version="unstable"
+          else
+            version="$(cat .redis_version)"
+          fi
+          echo "release_tag=$version" >> "$GITHUB_OUTPUT"
+          echo "Module build system version: $version"
+
+      - name: Determine module build system
+        id: module-build-system
+        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@master
+        with:
+          release_tag: ${{ steps.module-version.outputs.release_tag }}
     outputs:
       BUILD_OS: ${{ steps.parse.outputs.BUILD_OS }}
       TEST_OS: ${{ steps.parse.outputs.TEST_OS }}
+      MODERN_MODULES_BUILD: ${{ steps.module-build-system.outputs.MODERN_MODULES_BUILD }}
 
   build-n-test:
     uses: ./.github/workflows/build-n-test-all-distros.yml
@@ -59,12 +89,14 @@ jobs:
     with:
       BUILD_OS: ${{ needs.populate-env-vars.outputs.BUILD_OS }}
       TEST_OS: ${{ needs.populate-env-vars.outputs.TEST_OS }}
+      MODERN_MODULES_BUILD: ${{ needs.populate-env-vars.outputs.MODERN_MODULES_BUILD }}
       # Determine whether we should use special "unstable" release_tag. Assume
-      # that for unstable branch and for any external call, dispatch or schedule
-      # we are building unstable release. In other cases it's a regular PR/push
+      # that for unstable branch, PRs targeting unstable, and any external
+      # call, dispatch or schedule we are building unstable release. In other cases it's a regular PR/push
       # build without using specific release_tag.
       release_tag: >-
         ${{ (github.ref_name == 'unstable'
+        || github.base_ref == 'unstable'
         || github.event_name == 'workflow_dispatch'
         || github.event_name == 'workflow_call'
         || github.event_name == 'schedule')

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Determine module build system
         id: module-build-system
-        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@master
+        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@main
         with:
           release_tag: ${{ steps.module-version.outputs.release_tag }}
     outputs:

--- a/.github/workflows/rpm.yml
+++ b/.github/workflows/rpm.yml
@@ -52,36 +52,9 @@ jobs:
         id: parse
         uses: ./.github/actions/parse-env-file
 
-      - name: Determine Redis version for module build system
-        id: module-version
-        shell: bash
-        env:
-          IS_UNSTABLE_BUILD: >-
-            ${{ github.ref_name == 'unstable'
-            || github.base_ref == 'unstable'
-            || github.event_name == 'workflow_dispatch'
-            || github.event_name == 'workflow_call'
-            || github.event_name == 'schedule'
-            }}
-        run: |
-          set -euo pipefail
-          if [ "$IS_UNSTABLE_BUILD" = "true" ]; then
-            version="unstable"
-          else
-            version="$(cat .redis_version)"
-          fi
-          echo "release_tag=$version" >> "$GITHUB_OUTPUT"
-          echo "Module build system version: $version"
-
-      - name: Determine module build system
-        id: module-build-system
-        uses: redis-developer/redis-oss-release-automation/.github/actions/determine-module-build-system@main
-        with:
-          release_tag: ${{ steps.module-version.outputs.release_tag }}
     outputs:
       BUILD_OS: ${{ steps.parse.outputs.BUILD_OS }}
       TEST_OS: ${{ steps.parse.outputs.TEST_OS }}
-      MODERN_MODULES_BUILD: ${{ steps.module-build-system.outputs.MODERN_MODULES_BUILD }}
 
   build-n-test:
     uses: ./.github/workflows/build-n-test-all-distros.yml
@@ -89,7 +62,6 @@ jobs:
     with:
       BUILD_OS: ${{ needs.populate-env-vars.outputs.BUILD_OS }}
       TEST_OS: ${{ needs.populate-env-vars.outputs.TEST_OS }}
-      MODERN_MODULES_BUILD: ${{ needs.populate-env-vars.outputs.MODERN_MODULES_BUILD }}
       # Determine whether we should use special "unstable" release_tag. Assume
       # that for unstable branch, PRs targeting unstable, and any external
       # call, dispatch or schedule we are building unstable release. In other cases it's a regular PR/push


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes release packaging paths for versioned Redis tarballs and alters which git ref CI uses on PRs vs unstable pipelines, which can break builds or test mismatches if detection is wrong.
> 
> **Overview**
> RPM packaging now **branches on Redis’s module build system**: when the source is **unstable** or includes `modules/modules.yaml`, CI runs the **modern** flow (`modules-update`, Rust install, `make deploy`). Tagged releases **without** that manifest keep the **legacy** path (`BUILD_WITH_MODULES`, Rust, `make all` / `make install`).
> 
> Workflow checkout logic is tightened so **`unstable` is only checked out on non–pull_request runs** (push, dispatch, schedule, etc.). **Pull requests** use the PR head even when `release_tag` is `unstable`, while **`rpm.yml` still treats PRs targeting `unstable`** (`github.base_ref`) as unstable builds for naming and `release_tag`—so PR validation doesn’t blindly switch the whole tree to the `unstable` branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85df6c826730da9bd0a5d64b2ee918e3cd11b8b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->